### PR TITLE
Add build instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,12 @@ Specifically, [Lighthouse](https://developers.google.com/web/tools/lighthouse/)
 is used for the comparison.
 
 Run the tool without any arguments to see available command line options.
+
+## Build
+
+This will build a binary `fast` which you can optionally move to a location on
+your `$PATH`:
+
+```
+$ go build -o fast main.go
+```


### PR DESCRIPTION
I couldn't _quite_ remember the command I needed to use to do this, so add to the README for future reference.